### PR TITLE
Remove symlink to `.clang-format` in bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Collection of developer scripts, files, etc, for improving the developer process
 You can use `bootstrap` to "install" some of these tools, e.g., the `pre-commit` hook.
 
 Note that we currently use `ln -s` to "install" git hooks rather than just making a copy so that we can actually update it in the repository and everyone will benefit from the update).
-Also we "install" `.gitignore` and `.clang-format` files in the `root` directory to ignore all unused files and to have your code well-formatted.
 
 #### ***So, before you start the work with the current repo we recommend you to run this file with the following command in the root directory (Linux & macOS):***
 

--- a/bootstrap
+++ b/bootstrap
@@ -15,10 +15,5 @@ if [[ ! -f "${directory}/pre-commit" ]]; then
   exit 1
 fi
 
-if [[ ! -f "${directory}/.clang-format" ]]; then
-  printf "Failed to find '.clang-format'."
-  exit 1
-fi
-
 ln -s -f ../../dev-tools/pre-commit "${directory}/../.git/hooks/pre-commit"
-cp .clang-format "${directory}/.."
+


### PR DESCRIPTION
For now if you do git clone from `eventuals|eventuals-grpc|stout`
repos you will have already the symlink to the `clang-format` file
whick points to this repo. So there is no need to do it in
`bootstrap` file.