### PR TITLE
Introduce `clang-tidy-review` action

### DIFF
--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -14,8 +14,29 @@ jobs:
         cd dev-tools/ && ./bootstrap
     - name: Check all .cc , .h, .proto files for correct code format
       run: chmod +x dev-tools/check_style.sh && dev-tools/./check_style.sh
+
     - name: Install buildifier for .bzl files
       run: brew install buildifier
+
     - name: Check all .bzl, .bazel files for correct code format
-      run: chmod +x dev-tools/check_style_bzl.sh && dev-tools/./check_style_bzl.sh    
+      run: chmod +x dev-tools/check_style_bzl.sh && dev-tools/./check_style_bzl.sh
+
+    - name: Generate compile_commands.json
+      run: chmod +x dev-tools/generate_compile_commands.sh && dev-tools/./generate_compile_commands.sh       
+
+    - name: Use clang-tidy-review action to review any PR on code style
+      uses: ZedThree/clang-tidy-review@v0.7.0:
+      id: review
+      with:
+        # List of clang-tidy checks.
+        clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
+    
+    - name: Passed C++ style guide checks
+      # Doesn't work for now the if statement below.  
+      if: steps.static_analysis.outputs.total_comments > 0
+      run: exit 1
+        
+        
+
+      
 

--- a/generate_compile_commands.sh
+++ b/generate_compile_commands.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+INSTALL_DIR="/usr/local/bin"
+VERSION="0.5.2"
+
+# Download and symlink.
+(
+  cd "${INSTALL_DIR}" \
+  && curl -L "https://github.com/grailbio/bazel-compilation-database/archive/${VERSION}.tar.gz" | tar -xz \
+  && ln -f -s "${INSTALL_DIR}/bazel-compilation-database-${VERSION}/generate.py" bazel-compdb
+)
+
+bazel-compdb # This will generate compile_commands.json in your workspace root.


### PR DESCRIPTION
This PR added `clang-tidy-review` action which helps us to review
our PR's automatically on code style. Also added `generate_compile
_commands.sh` script which generates compile_commands.json. (data-
base for compile options, needed for clang-tidy).