### PR TITLE
Introduce PowerShell script to replace unix symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ Note that we currently use `ln -s` to "install" git hooks rather than just makin
 ```
 cd dev-tools && ./bootstrap
 ```
+
+## `symlinks.ps1`
+
+On `Windows` unix symlink doesn't not work as expected (check [this](https://github.com/3rdparty/eventuals/issues/153) issue). That's why we have created `symlinks.ps1` PowerShell script. To run this script do the following:
+
+- Make sure if you are able to create symlinks on Windows:
+    - Check [this](https://github.com/git-for-windows/git/wiki/Symbolic-Links) if you do not know how to allow non-admins to create symbolic links.
+- Unblock the script
+    - Right-click the script and choose Properties. In the Properties dialog, if available, select the Unblock checkbox and press OK.
+- If it still doesn’t work, type the following in a PowerShell window: 
+    - ```Set-ExecutionPolicy -ExecutionPolicy RemoteSigned```
+- Run `symlinks.ps1` from the workspace containing the `dev-tools` submodule:
+    - ```path\to\dev-tools\symlinks.ps1```

--- a/symlinks.ps1
+++ b/symlinks.ps1
@@ -1,0 +1,92 @@
+# This PowerShell script finds all unix symlinks and replace them
+# with the Windows symlinks.
+
+# Create file_list.txt and fill it with all files in current repo.
+$file_exists = Test-Path -Path file_list.txt -PathType Leaf
+if (-Not $file_exists) {
+    git ls-files -s > file_list.txt
+}
+else {
+    Clear-Content -Path "file_list.txt"
+}
+
+# Find all unix symlinks.
+$sym_links = Select-String -Path file_list.txt -AllMatches -Pattern "120000"
+
+# Get the full path of the symlink.
+# By default command above (Select-String) will return
+# the line which has: 
+#   ..\path\to\file:[x]:mode sha stage_number  \t  \path\to\symlink.
+# We will split this line by tab ("\t") separator. This function 
+# returns the full path to the symlink.   
+function GetSymlinkPath {
+    param (
+        [string[]]$line
+    )
+
+    if ($line.Length -eq 0) {
+        return ""
+    }
+
+    $path = $line.Split("`t")
+    
+    if ($path.Count -ne 2) {
+        Write-Error "Expected 2 items."  
+        exit 1
+    }    
+
+    return $path[1]
+}
+
+# Put to the sym_link_path_array the paths of all symbolic links.
+[array]$sym_link_path_array = @()
+
+if ($sym_links.Count -ne 0) {
+    foreach ($sym_link in $sym_links) {      
+        $path = GetSymlinkPath($sym_link.ToString())
+        if ($path.Length -ne 0) {
+            $sym_link_path_array += $path 
+        }
+    }
+}
+
+# Transform unix symlinks into the Windows symlinks.
+if ($sym_link_path_array.Count -eq 0) {
+    exit 0
+}
+
+# On Unix in file's path there is "/". So we should replace it with "\".
+function GetWindowsPathToFile {
+    param (
+        [string[]]$unix_path
+    )
+    
+    if ($unix_path.Length -eq 0) {
+        return ""
+    }
+    else {
+        return $unix_path.Replace("/", "\")
+    }
+}
+
+foreach ($symlink in $sym_link_path_array) {
+    # Get unix path to the original file.
+    $unix_path_origin_file = Get-Content -Path $symlink
+    # Get Windows path to the original file.
+    $win_path_origin_file = GetWindowsPathToFile($unix_path_origin_file) 
+
+    # Remove unix symlink.
+    if (Test-Path -Path  $symlink -PathType Leaf) {
+        Remove-Item -Path $symlink  
+    }
+
+    if ($win_path_origin_file.Length -eq 0) {
+        continue
+    }
+
+    # Create Windows symlink.
+    if (Test-Path -Path  $win_path_origin_file -PathType Leaf) {
+        cmd /c mklink $symlink $win_path_origin_file
+    }
+    git update-index --assume-unchanged $symlink
+}


### PR DESCRIPTION
This PR should [fix](https://github.com/3rdparty/eventuals/issues/153) this issue. In general `symlinks.ps1` was created to find all unix symlinks and make them be as Windows symlinks. It is needed cause unix symlinks on Windows are treated as text files! 