### PR TITLE
Make clang-format auto-format to our required 80 char line length.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ BinPackParameters: false
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
-ColumnLimit: 0
+ColumnLimit: 80
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 4


### PR DESCRIPTION
This should make clang-format auto-format code to match the limit we check in https://github.com/3rdparty/dev-tools/blob/main/check_line_length.sh.

Note that this might cause several files to be reformatted on their next edit.

e.g. this change make clang-format change this:
```
  auto o = std::make_unique<Operation>(Build(operation(5, std::move(promise1))));
```

to this:
```
  auto o =
      std::make_unique<Operation>(Build(operation(5, std::move(promise1))));
```