### PR TITLE
Share the nobuild GitHub workflow via dev-tools

### DIFF
--- a/.github/workflows/nobuild.yml
+++ b/.github/workflows/nobuild.yml
@@ -1,0 +1,20 @@
+# Workflow for changes that don't need to run "Build and Test".
+#
+# Note: The job name of this stub "build" must match the name of the real
+# Build and Test job that this is trying to replace.
+name: nobuild
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - '**.md'
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
Stubbing out workflows with replacement no-op workflows is the
recommended way to skip required workflows for some file types but to
require them for others.

A major downside of sharing only some workflows like this is that file
path inclusions / exclusions need to be synchronized across repositories
which can't be done atomically.

See https://github.com/3rdparty/eventuals/issues/176 and
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
