### PR TITLE
Make flakiness script run count configurable

### DIFF
--- a/measure_flakiness.sh
+++ b/measure_flakiness.sh
@@ -2,22 +2,27 @@
 #
 # Measures the flakiness (the percentage of failures) of the given command.
 #
-# Usage: measure_flakiness.sh $COMMAND_TO_RUN
+# Usage: [RUN_COUNT=XXX] measure_flakiness.sh $COMMAND_TO_RUN
 
-RUN_COUNT=10
-echo "Running the following command ${RUN_COUNT} times to measure flakiness: ${@}"
+run_count=${RUN_COUNT:-10}
+if [ ${run_count} -le 0 ]; then
+    echo "RUN_COUNT must be positive"
+    exit 1
+fi
+echo "Running the following command ${run_count} times to measure flakiness: ${@}"
  
 failure_count=0
-for (( i=0; i<$RUN_COUNT; i++ ))
+for (( i=0; i<${run_count}; i++ ))
 do
+    echo "Run $((i + 1)) of ${run_count}"
     if ! ${@};
     then
         failure_count=$((failure_count + 1))
     fi
 done
 
-success_count=$((RUN_COUNT - failure_count))
+success_count=$((run_count - failure_count))
 # Round up when dividing so 0.1% flaky is reported as 1%, not 0%. See
 # https://stackoverflow.com/a/2395294
-flaky_percentage=$(((failure_count * 100 + RUN_COUNT - 1) / RUN_COUNT))
-echo "${success_count}/${RUN_COUNT} runs succeeded (${flaky_percentage}% flaky)"
+flaky_percentage=$(((failure_count * 100 + run_count - 1) / run_count))
+echo "${success_count}/${run_count} runs succeeded (${flaky_percentage}% flaky)"


### PR DESCRIPTION
Also add streaming run count which helps track progress for long-running
commands.

Sample output:
```bash
$ RUN_COUNT=5 ./measure_flakiness.sh true
Running the following command 5 times to measure flakiness: true
Run 1 of 5
Run 2 of 5
Run 3 of 5
Run 4 of 5
Run 5 of 5
5/5 runs succeeded (0% flaky)
```
