### PR TITLE
Use github action path variable

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -8,8 +8,8 @@ runs:
   steps:
     - name: Check all .cc , .h, .proto files for correct code style
       run: | 
-        chmod +x dev-tools/check-code-style/check_style_of_all_files.sh
-        dev-tools/check-code-style/check_style_of_all_files.sh
+        chmod +x ${{ github.action_path }}/check_style_of_all_files.sh
+        ${{ github.action_path }}/check_style_of_all_files.sh
       shell: bash
 
     - name: Install buildifier for .bzl files
@@ -18,6 +18,6 @@ runs:
 
     - name: Check all .bzl, .bazel files for correct code style
       run: |
-        chmod +x dev-tools/check-code-style/check_style_bzl.sh
-        dev-tools/check-code-style/check_style_bzl.sh    
+        chmod +x ${{ github.action_path }}/check_style_bzl.sh
+        ${{ github.action_path }}/check_style_bzl.sh    
       shell: bash


### PR DESCRIPTION
We use `${{ github.action_path  }}` to be aware of the full path
where this action is located. So, we can easily run this action
non depending on the path where the submodule with this action is
located.