### PR TITLE
Update the way of grabing files for code style checks

### DIFF
--- a/check-code-style/check_style_of_all_files.sh
+++ b/check-code-style/check_style_of_all_files.sh
@@ -2,11 +2,40 @@
 
 source dev-tools/check-code-style/check_style.sh
 
+path_to_find_files_for_checks="."
+
+if [ $# -eq 0 ]
+then
+  tput bold
+  tput setaf 3
+  printf "Warning: "
+  tput sgr0
+  printf "this script will check all files which"
+  printf " are located on the path from which this"
+  printf " script has been run.\n"
+  printf "If you want to check files from the"
+  printf " specific path you can run this script" 
+  printf " with the argument which specifies this path.\n"
+  printf "e.g: some/path/check_style_of_all_files.sh some/dir\n"
+elif [ $# -gt 1 ]
+then
+  tput bold
+  tput setaf 1
+  printf "Error: "
+  tput sgr0
+  printf "this script can be run only with 0 or 1 argument"
+  printf " which specifies the path where you wanna search"
+  printf " files for checking code style.\n"
+  exit 1
+else
+  path_to_find_files_for_checks=$1
+fi
+
 # Check every file for correct code style.
 check_style_of_all_files() {
   # Find all files we want to check in the workspace.
   IFS=:
-  file_paths=$(find . -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.proto')
+  file_paths=$(find ${path_to_find_files_for_checks} -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.proto')
   unset IFS
 
   if [[ ${#file_paths} == 0 ]]; then


### PR DESCRIPTION
The basic idea is to let users run this script with 1 argument
which specifies necessary directory to be scanned for files
they wanna check. So here is an example how users can call this
script:
```
	./some/path/check_style_of_all_files.sh some/dir
```
Users even can call this script without any argument passed.
If so, then this scipt will search recursively all files needed
for code style checks in the directory from which this script
has been run. Check [this](https://github.com/3rdparty/dev-tools/blob/bed84c269ed97efc485c98880866d0bed4c58173/check-code-style/check_style_of_all_files.sh#L9) line in the `check_style_of_all_files.sh`. 
For example, immagine that we have the following
structure:
```
--root:
   |
   |___subdirectory1
            |
            |___subdirectory2
            |        |
            |        |
            |        |___dev-tools
            |	             |
            |                |______check-code-style
            |                                |
            |                                |___________check_style_of_all_files.sh
            |
            |___subdirectory3

```
And immagine now that we run script from the `subdirectory2`. In this
case the script will find only all files which are located recursively
or not in the `subdirectory2`.