### PR TITLE
Configure bazel to print failure logs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,9 @@
 # Include this file in another .bazelrc with a line like:
 #   try-import submodules/dev-tools/.bazelrc
 
+# Print failed test logs to the console by default.
+build --test_output=errors
+
 # Define an https://github.com/google/sanitizers/wiki/AddressSanitizer config
 # to catch common memory errors like use-after-free.
 # See https://stackoverflow.com/a/57733619.


### PR DESCRIPTION
Sample failure before:
```
INFO: Found 1 test target...                                                              
FAIL: //tests/test_object_store_conn:test (see /home/alexmc/.cache/dazel/respect-integrati
on/execroot/com_github_reboot_dev_respect_integration/bazel-out/k8-fastbuild/testlogs/test
s/test_object_store_conn/test/test.log)                                                   
Target //tests/test_object_store_conn:test up-to-date:                                    
  bazel-bin/tests/test_object_store_conn/test                                             
INFO: Elapsed time: 0.610s, Critical Path: 0.41s                                          
INFO: 2 processes: 2 processwrapper-sandbox.                                              
INFO: Build completed, 1 test FAILED, 2 total actions                                     
//tests/test_object_store_conn:test                                      FAILED in 0.2s    
  /home/alexmc/.cache/dazel/respect-integration/execroot/com_github_reboot_dev_respect_int
egration/bazel-out/k8-fastbuild/testlogs/tests/test_object_store_conn/test/test.log   
```

Sample failure after:
```                                                              
INFO: Found 1 test target...                                                              
FAIL: //tests/test_object_store_conn:test (see /home/alexmc/.cache/dazel/respect-integrati
on/execroot/com_github_reboot_dev_respect_integration/bazel-out/k8-fastbuild/testlogs/test
s/test_object_store_conn/test/test.log)                                                   
INFO: From Testing //tests/test_object_store_conn:test:                                   
==================== Test output for //tests/test_object_store_conn:test:                 
E                                                                                         
======================================================================
ERROR: test_on_kubernetes (__main__.TestObjectStore)                                      
Run the actual tests from a client on kubernetes.                                         
----------------------------------------------------------------------                    
Traceback (most recent call last):                                                        
  File "/home/alexmc/.cache/dazel/respect-integration/sandbox/processwrapper-sandbox/11/ex
ecroot/com_github_reboot_dev_respect_integration/bazel-out/k8-fastbuild/bin/tests/test_obj
ect_store_conn/test.runfiles/com_github_reboot_dev_respect_integration/tests/test_object_s
tore_conn/test.py", line 11, in test_on_kubernetes                    
    self.assertEqual(0, run_local_kubernetes_test.run_test())
NameError: name 'run_local_kubernetes_test' is not defined                                
                                                                                          
----------------------------------------------------------------------                    
Ran 1 test in 0.001s                                                                      
                                                                                          
FAILED (errors=1)                                                                         
================================================================================
Target //tests/test_object_store_conn:test up-to-date:
  bazel-bin/tests/test_object_store_conn/test                                             
INFO: Elapsed time: 0.618s, Critical Path: 0.42s                                          
INFO: 2 processes: 2 processwrapper-sandbox.                                              
INFO: Build completed, 1 test FAILED, 2 total actions                                     
//tests/test_object_store_conn:test                                      FAILED in 0.2s   
  /home/alexmc/.cache/dazel/respect-integration/execroot/com_github_reboot_dev_respect_int
egration/bazel-out/k8-fastbuild/testlogs/tests/test_object_store_conn/test/test.log   
```