### PR TITLE
Add Dockerfile.dazel to repo

### DIFF
--- a/Dockerfile.dazel
+++ b/Dockerfile.dazel
@@ -1,0 +1,48 @@
+# NOTE: FROM must be the same base image we use to create any
+# container images otherwise what we build with will be different than
+# what we run with!
+#
+# See 'bazel/deps.bzl' which should use the same image as here.
+FROM ubuntu:latest
+ARG BAZEL_VERSION=4.2.1
+ARG CLANG_VERSION=14
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y \
+            autoconf \
+            build-essential \
+            ca-certificates \
+            curl \
+            gnupg \
+            git \
+            lsb-release \
+            make \
+            openssh-client \
+            python3 \
+            python3-distutils \
+            software-properties-common \
+            wget \
+    # Install docker
+    && curl -fsSL https://get.docker.com | sh \
+    # And install Bazel too.
+    && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > \
+        /etc/apt/sources.list.d/bazel.list \
+    && curl -fsSL https://bazel.build/bazel-release.pub.gpg | apt-key add - \
+    && apt-get update && apt-get install -y \
+        bazel=${BAZEL_VERSION} \
+    # Install clang
+    && wget -O /tmp/llvm.sh "https://apt.llvm.org/llvm.sh" \
+    && chmod +x /tmp/llvm.sh \
+    && /tmp/llvm.sh ${CLANG_VERSION} \
+    && rm /tmp/llvm.sh \
+    # Cleanup.
+    && apt-get purge --auto-remove -y \
+    && rm -rf /etc/apt/sources.list.d/bazel.list \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make python mean python3
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Make clang mean clang-xx
+RUN ln -s /usr/bin/clang-${CLANG_VERSION} /usr/bin/clang


### PR DESCRIPTION
We are currently using `dazel` in three places. I believe that we should
be able to use the same `Dockerfile` for all three cases. So to ease
maintainability and streamline development I propose this new(ish)
`Dockerfile` based on the updated one used in `respect`.