### PR TITLE
Cleaner .bazelrc test_output config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,7 +4,7 @@
 #   try-import submodules/dev-tools/.bazelrc
 
 # Print failed test logs to the console by default.
-build --test_output=errors
+test --test_output=errors
 
 # Define an https://github.com/google/sanitizers/wiki/AddressSanitizer config
 # to catch common memory errors like use-after-free.


### PR DESCRIPTION
`--test_output=errors` should probably be specified on `test` (since it's a test option) rather than `build` (though `build` seems to work just fine).