### PR TITLE
Update to bazel 5.0.0

### DIFF
--- a/Dockerfile.dazel
+++ b/Dockerfile.dazel
@@ -4,7 +4,7 @@
 #
 # See 'bazel/deps.bzl' which should use the same image as here.
 FROM ubuntu:latest
-ARG BAZEL_VERSION=4.2.1
+ARG BAZEL_VERSION=5.0.0
 ARG CLANG_VERSION=14
 
 RUN apt-get update \


### PR DESCRIPTION
Bazel 5 used to generate build errors on our code:
https://github.com/3rdparty/eventuals-grpc/issues/65

but that was fixed with a newer gRPC release:
https://github.com/3rdparty/eventuals/pull/247
