### PR TITLE
[Submodules-sync workflow update part_1] Upload bash scripts

### DIFF
--- a/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
+++ b/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+# The scripts requires the $REPO and $GITHUB_TOKEN to be presented in environment variables.
 
-PR_TITLE=$1
-ISSUE_TITLE=$2
+# The scripts gets Pull Request and Issue titles as arguments.
+# Any spaces in the titles must be replaced with "+".
+# Usage example:
+# ./check-if-issue-and-pr-exist.sh Submodule-sync+Update+submodule+to+its+latest+version Submodule+sync+failed+for+repo
+
+PR_TITLE=$1     # Pull Request title - the first argument
+ISSUE_TITLE=$2  # Issue title - the second argument
 
 # The API URLs in conditions below search for any existing pull requests and issues using wildcard and
 # generates ISSUE_EXISTS and PR_EXISTS environment variables and places those in the environment for next steps

--- a/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
+++ b/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# The API URLs in conditions below search for any existing pull requests and issues using wildcard and
+# generates ISSUE_EXISTS and PR_EXISTS environment variables and places those in the environment for next steps
+# through $GITHUB_ENV;
+# See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+# See docs: https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests--parameters
+# If the issue exists we also set the `ISSUE_NUMBER` environment variable.
+
+PR_NUMBER=$(curl -s --request GET \
+  --url https://api.github.com/search/issues\?q=is:pull-request+is:open+repo:$REPO+in:title+Submodule-sync+$MATRIX_PATH+Update+submodule+to+its+latest+version \
+  --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
+ISSUE_NUMBER=$(curl -s --request GET \
+  --url https://api.github.com/search/issues\?q=is:issue+is:open+repo:$REPO+in:title+Submodule+sync+failed+for+"$MATRIX_PATH" \
+  --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
+echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV;
+echo "ISSUE_EXISTS=$(if [[ $ISSUE_NUMBER ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV;
+echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV;
+echo "PR_EXISTS=$(if [[ $PR_NUMBER ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV;

--- a/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
+++ b/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+PR_TITLE=$1
+ISSUE_TITLE=$2
+
 # The API URLs in conditions below search for any existing pull requests and issues using wildcard and
 # generates ISSUE_EXISTS and PR_EXISTS environment variables and places those in the environment for next steps
 # through $GITHUB_ENV;
@@ -8,11 +11,11 @@
 # If the issue exists we also set the `ISSUE_NUMBER` environment variable.
 
 PR_NUMBER=$(curl -s --request GET \
-  --url https://api.github.com/search/issues\?q=is:pull-request+is:open+repo:$REPO+in:title+Submodule-sync+$MATRIX_PATH+Update+submodule+to+its+latest+version \
-  --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
+  --url https://api.github.com/search/issues\?q=is:pull-request+is:open+repo:$REPO+in:title+$PR_TITLE \
+  --header "Authorization: token $GITHUB_TOKEN" | jq -r ".items[].number" | head -n 1);
 ISSUE_NUMBER=$(curl -s --request GET \
-  --url https://api.github.com/search/issues\?q=is:issue+is:open+repo:$REPO+in:title+Submodule+sync+failed+for+"$MATRIX_PATH" \
-  --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
+  --url https://api.github.com/search/issues\?q=is:issue+is:open+repo:$REPO+in:title+$ISSUE_TITLE \
+  --header "Authorization: token $GITHUB_TOKEN" | jq -r ".items[].number" | head -n 1);
 echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV;
 echo "ISSUE_EXISTS=$(if [[ $ISSUE_NUMBER ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV;
 echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV;

--- a/.github/workflows/scripts/per-submodule-build-matrix.sh
+++ b/.github/workflows/scripts/per-submodule-build-matrix.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Update references.
+git submodule update --recursive --remote
+
+# The following condition is needed to set required outputs.
+# The step generates one output: `path_matrix`.
+# `path_matrix` output contains list of all submodules within a repo.
+# The flag is used by the main build job.
+echo "::set-output name=path_matrix::[$(git config --file ../../../.gitmodules --get-regexp path | \
+awk '{ print $2 }' | \
+awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]"

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -54,7 +54,7 @@ jobs:
     # We set strategy matrix to work with changes of each submodule separately.
     strategy:
       matrix:
-         path: ${{ fromJson(needs.build-matrix.outputs.path_matrix) }}
+        path: ${{ fromJson(needs.build-matrix.outputs.path_matrix) }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
The PR addresses issue https://github.com/3rdparty/dev-tools/issues/41.

I am going to cover the issue in the following steps and order (with minimal downtime considered):
**1. Upload bash scripts that are supposed to replace shell steps in Submodules-sync workflow. - [part_1](https://github.com/3rdparty/dev-tools/pull/42).**
2. Add `inputs` to the workflow to be able to specify scripts directory manually from parent workflow (`respect` and `eventuals` accordingly) because it could be different from repos to repo. - [part_2](https://github.com/3rdparty/dev-tools/pull/43).
3. Modify the workflow to use bash scripts instead of shell steps. - [part_2](https://github.com/3rdparty/dev-tools/pull/43)
4. Update the Submodules-sync workflow to use `inputs` in `respect` repo. - [part_3](https://github.com/reboot-dev/respect/pull/354).
5. Update the Submodules-sync workflow to use `inputs` in `eventuals` repo. - [part_4](https://github.com/3rdparty/eventuals/pull/359).

Part_1 (this PR) needs to be merged first.
Then Part_2.
Part_3 and Part_4 need to merged right after Part_2 is merged.
Until all the PRs are merged we will have Submodules-sync for `respect` and `eventuals` broken for some period of time.