### PR TITLE
[Submodules-sync workflow update part_2] Wrap shell steps to scripts

### DIFF
--- a/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
+++ b/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# The API URLs in conditions below search for any existing pull requests and issues using wildcard and
+# generates ISSUE_EXISTS and PR_EXISTS environment variables and places those in the environment for next steps
+# through $GITHUB_ENV;
+# See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+# See docs: https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests--parameters
+# If the issue exists we also set the `ISSUE_NUMBER` environment variable.
+
+PR_NUMBER=$(curl -s --request GET \
+  --url https://api.github.com/search/issues\?q=is:pull-request+is:open+repo:$REPO+in:title+Submodule-sync+$MATRIX_PATH+Update+submodule+to+its+latest+version \
+  --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
+ISSUE_NUMBER=$(curl -s --request GET \
+  --url https://api.github.com/search/issues\?q=is:issue+is:open+repo:$REPO+in:title+Submodule+sync+failed+for+"$MATRIX_PATH" \
+  --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
+echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV;
+echo "ISSUE_EXISTS=$(if [[ $ISSUE_NUMBER ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV;
+echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV;
+echo "PR_EXISTS=$(if [[ $PR_NUMBER ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV;

--- a/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
+++ b/.github/workflows/scripts/check-if-issue-and-pr-exist.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# The scripts requires the $REPO and $GITHUB_TOKEN to be presented in environment variables.
+# The scripts requires the REPO and GITHUB_TOKEN to be presented in environment variables.
+# REPO is repository owner and name, e.g. 'reboot-dev/dev-tools'
+# GITHUB_TOKEN is a GitHub Personal Access Token
 
 # The scripts gets Pull Request and Issue titles as arguments.
 # Any spaces in the titles must be replaced with "+".

--- a/.github/workflows/scripts/per-submodule-build-matrix.sh
+++ b/.github/workflows/scripts/per-submodule-build-matrix.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Update references.
+git submodule update --recursive --remote
+
+# The following condition is needed to set required outputs.
+# The step generates one output: `path_matrix`.
+# `path_matrix` output contains list of all submodules within a repo.
+# The flag is used by the main build job.
+echo "::set-output name=path_matrix::[$(git config --file ../../../.gitmodules --get-regexp path | \
+awk '{ print $2 }' | \
+awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]"

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -68,10 +68,9 @@ jobs:
     # submodule.
     - name: Check if PR and issue already exist
       env:
-        MATRIX_PATH: ${{ matrix.path }}
         REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ secrets.private_repo_access_as_rebot_token }}
-      run: ./check-if-issue-and-pr-exist.sh
+      run: ./check-if-issue-and-pr-exist.sh Submodule-sync+${{ matrix.path }}+Update+submodule+to+its+latest+version Submodule+sync+failed+for+"${{ matrix.path }}"
       working-directory: ${{ env.SCRIPTS_DIRECTORY }}
 
     - name: Close open issue

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -6,9 +6,15 @@ name: Submodules Sync
 
 on:
   workflow_call:
+    inputs:
+      scripts_directory:
+        required: true
     secrets:
       private_repo_access_as_rebot_token:
         required: true
+
+env:
+  SCRIPTS_DIRECTORY: ${{ inputs.scripts_directory }}
 
 jobs:
   # Since we want to create one PR per each submodule on submodule change
@@ -25,16 +31,8 @@ jobs:
           submodules: recursive
       - id: set-matrix
         name: Set matrix based on modified submodules
-        run: |
-          # Update references.
-          git submodule update --recursive --remote
-          # The following condition is needed to set required outputs.
-          # The step generates one output: `path_matrix`.
-          # `path_matrix` output contains list of all submodules within a repo.
-          # The flag is used by the main build job.
-          echo "::set-output name=path_matrix::[$(git config --file .gitmodules --get-regexp path | \
-          awk '{ print $2 }' | \
-          awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]"
+        run: ./per-submodule-build-matrix.sh
+        working-directory: ${{ env.SCRIPTS_DIRECTORY }}
     outputs:
       path_matrix: ${{ steps.set-matrix.outputs.path_matrix }}
 
@@ -60,28 +58,20 @@ jobs:
         shell: bash
 
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.private_repo_access_as_rebot_token }}
+        submodules: recursive
     # The following step checks whether the issue and pull request have already been created or not for the same
     # submodule.
     - name: Check if PR and issue already exist
-      # The API URLs in conditions below search for any existing pull requests and issues using wildcard and
-      # generates ISSUE_EXISTS and PR_EXISTS environment variables and places those in the environment for next steps
-      # through $GITHUB_ENV;
-      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-      # See docs: https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests--parameters
-      # If the issue exists we also set the `ISSUE_NUMBER` environment variable.
-      # The folowing style of command is YAML folded style (with '>') which is supported by GitHub Actions.
-      # Newlines will be replaced with spaces converting the code to one line.
-      run: >
-        PR_NUMBER=$(curl -s --request GET
-        --url https://api.github.com/search/issues\?q=is:pull-request+is:open+repo:${{ github.repository }}+in:title+Submodule-sync+${{ matrix.path }}+Update+submodule+to+its+latest+version
-        --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
-        ISSUE_NUMBER=$(curl -s --request GET
-        --url https://api.github.com/search/issues\?q=is:issue+is:open+repo:${{ github.repository }}+in:title+Submodule+sync+failed+for+"${{ matrix.path }}"
-        --header 'Authorization: token ${{ secrets.private_repo_access_as_rebot_token }}' | jq -r ".items[].number" | head -n 1);
-        echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV;
-        echo "ISSUE_EXISTS=$(if [[ $ISSUE_NUMBER ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV;
-        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV;
-        echo "PR_EXISTS=$(if [[ $PR_NUMBER ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV;
+      env:
+        MATRIX_PATH: ${{ matrix.path }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.private_repo_access_as_rebot_token }}
+      run: ./check-if-issue-and-pr-exist.sh
+      working-directory: ${{ env.SCRIPTS_DIRECTORY }}
 
     - name: Close open issue
       if: env.ISSUE_EXISTS == 'true' && env.PR_EXISTS == 'false'

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -7,7 +7,7 @@ name: Submodules Sync
 on:
   workflow_call:
     inputs:
-      scripts_directory:
+      devtools_directory:
         required: true
         type: string
     secrets:
@@ -15,7 +15,7 @@ on:
         required: true
 
 env:
-  SCRIPTS_DIRECTORY: ${{ inputs.scripts_directory }}
+  SCRIPTS_DIRECTORY: ${{ inputs.devtools_directory }}/.github/workflow/scripts
 
 jobs:
   # Since we want to create one PR per each submodule on submodule change

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -9,6 +9,7 @@ on:
     inputs:
       scripts_directory:
         required: true
+        type: string
     secrets:
       private_repo_access_as_rebot_token:
         required: true

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -54,7 +54,7 @@ jobs:
     # We set strategy matrix to work with changes of each submodule separately.
     strategy:
       matrix:
-         path: ${{ fromJson(needs.build-matrix.outputs.path_matrix) }}
+        path: ${{ fromJson(needs.build-matrix.outputs.path_matrix) }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -15,7 +15,7 @@ on:
         required: true
 
 env:
-  SCRIPTS_DIRECTORY: ${{ inputs.devtools_directory }}/.github/workflow/scripts
+  SCRIPTS_DIRECTORY: ${{ inputs.devtools_directory }}/.github/workflows/scripts
 
 jobs:
   # Since we want to create one PR per each submodule on submodule change


### PR DESCRIPTION
The PR addresses issue https://github.com/3rdparty/dev-tools/issues/41.

I am going to cover the issue in the following steps and order (with minimal downtime considered):
1. Upload bash scripts that are supposed to replace shell steps in Submodules-sync workflow. - [part_1](https://github.com/3rdparty/dev-tools/pull/42).
**2. Add `inputs` to the workflow to be able to specify scripts directory manually from parent workflow (`respect` and `eventuals` accordingly) because it could be different from repos to repo. - [part_2](https://github.com/3rdparty/dev-tools/pull/43).**
**3. Modify the workflow to use bash scripts instead of shell steps. - [part_2](https://github.com/3rdparty/dev-tools/pull/43)**
4. Update the Submodules-sync workflow to use `inputs` in `respect` repo. - [part_3](https://github.com/reboot-dev/respect/pull/354).
5. Update the Submodules-sync workflow to use `inputs` in `eventuals` repo. - [part_4](https://github.com/3rdparty/eventuals/pull/359).

Part_1 (this PR) needs to be merged first.
Then Part_2.
Part_3 and Part_4 need to be merged right after Part_2 is merged.
Until all the PRs are merged we will have Submodules-sync for `respect` and `eventuals` broken for some period of time.