### PR TITLE
[Submodules-sync] Fix path in script

### DIFF
--- a/.github/workflows/scripts/per-submodule-build-matrix.sh
+++ b/.github/workflows/scripts/per-submodule-build-matrix.sh
@@ -7,6 +7,6 @@ git submodule update --recursive --remote
 # The step generates one output: `path_matrix`.
 # `path_matrix` output contains list of all submodules within a repo.
 # The flag is used by the main build job.
-echo "::set-output name=path_matrix::[$(git config --file ../../../.gitmodules --get-regexp path | \
+echo "::set-output name=path_matrix::[$(git config --file ../../../../../.gitmodules --get-regexp path | \
 awk '{ print $2 }' | \
 awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]"


### PR DESCRIPTION
Fixing path of file `.gitmodules` in script.
Related issue: https://github.com/3rdparty/eventuals/issues/369.