### PR TITLE
Add script which updates eventuals commit and shallow_since

### DIFF
--- a/.github/workflows/scripts/update-eventuals-git-repository.sh
+++ b/.github/workflows/scripts/update-eventuals-git-repository.sh
@@ -37,4 +37,11 @@ do
 
 done < "$file"
 
+# Check for existence of buildifier.
+which buildifier >/dev/null
+if [[ $? != 0 ]]; then
+  printf "Failed to find 'buildifier'\n"
+  exit 1
+fi
+
 buildifier $file

--- a/.github/workflows/scripts/update-eventuals-git-repository.sh
+++ b/.github/workflows/scripts/update-eventuals-git-repository.sh
@@ -1,0 +1,40 @@
+# !/bin/bash
+
+file=$1
+
+commit=$(git log -n 1 --pretty=format:"%H")
+shallow_since=$(git log -n 1 --date=raw --pretty=format:"%cd")
+
+git_repository_needed=False
+
+while IFS= read -r line
+do
+  if [[ "${line}" =~ .*"name = \"com_github_3rdparty_eventuals\"".* ]];
+  then
+    git_repository_needed=True
+    echo "line with name of git_repository needed: ${line}"
+  fi
+
+  if [[ "${line}" =~ .*"commit = ".* ]];
+  then
+    if [ $git_repository_needed = True ];
+    then
+      new_commit_replace="commit = \"${commit}\","
+      sed -i "s/$line/$new_commit_replace/" $file
+      echo $new_commit_replace
+    fi    
+  fi
+
+  if [[ "${line}" =~ .*"shallow_since = ".* ]];
+  then
+    if [ $git_repository_needed = True ];
+    then
+      new_shallow_replace="shallow_since = \"${shallow_since}\","
+      sed -i "s/$line/$new_shallow_replace/" $file
+      echo $new_shallow_replace
+    fi    
+  fi
+
+done < "$file"
+
+buildifier $file

--- a/.github/workflows/scripts/update-eventuals-git-repository.sh
+++ b/.github/workflows/scripts/update-eventuals-git-repository.sh
@@ -1,40 +1,70 @@
 # !/bin/bash
 
+# File passed to this script as an argument in which we gonna
+# update 'git_repository' bazel rule for eventuals 
+# (WORKSPACE.bazel usually).
 file=$1
 
-commit=$(git log -n 1 --pretty=format:"%H")
-shallow_since=$(git log -n 1 --date=raw --pretty=format:"%cd")
+# The last commit for eventuals.
+commit=$2
 
+# The latest shallow_since for eventuals.
+shallow_since=$3
+
+if [[ ! -f "$file" ]]; then
+    echo "$file doesn't exist"
+    exit 1
+fi
+
+if [[ ${#commit} == 0 ]]; then
+    echo "Incorrect commit value."
+    exit 1
+fi
+
+if [[ ${#shallow_since} == 0 ]]; then
+    echo "Incorrect shallow_since value."
+    exit 1
+fi
+
+# This flag indicates whether or not we process correct
+# 'git_repository' rule for eventuals in current $file.
 git_repository_needed=False
+
+# Flags to help understand whether or not all updates
+# (commit and shallow_since) are done.
+is_commit_replaced=False
+is_shallow_replaced=False
 
 while IFS= read -r line
 do
+  # Check if current line of the file contains necessary name
+  # of the git_repository which we gonna update with commit
+  # and shallow_since.
   if [[ "${line}" =~ .*"name = \"com_github_3rdparty_eventuals\"".* ]];
   then
     git_repository_needed=True
-    echo "line with name of git_repository needed: ${line}"
   fi
 
-  if [[ "${line}" =~ .*"commit = ".* ]];
+  # This is a right place for commit updates.
+  if [[ "${line}" =~ .*"commit = ".* && $git_repository_needed = True ]];
   then
-    if [ $git_repository_needed = True ];
-    then
-      new_commit_replace="commit = \"${commit}\","
-      sed -i "s/$line/$new_commit_replace/" $file
-      echo $new_commit_replace
-    fi    
+    new_commit_replace="commit = \"${commit}\","
+    sed -i "s/$line/$new_commit_replace/" $file
+    is_commit_replaced=True
   fi
 
-  if [[ "${line}" =~ .*"shallow_since = ".* ]];
+  # This is a right place for shallow_since updates.
+  if [[ "${line}" =~ .*"shallow_since = ".* && $git_repository_needed = True ]];
   then
-    if [ $git_repository_needed = True ];
-    then
-      new_shallow_replace="shallow_since = \"${shallow_since}\","
-      sed -i "s/$line/$new_shallow_replace/" $file
-      echo $new_shallow_replace
-    fi    
+    new_shallow_replace="shallow_since = \"${shallow_since}\","
+    sed -i "s/$line/$new_shallow_replace/" $file
+    is_shallow_replaced=True
   fi
 
+  if [[ $is_commit_replaced = True && $is_shallow_replaced = True ]];
+  then
+    break
+  fi
 done < "$file"
 
 # Check for existence of buildifier.

--- a/.github/workflows/update-eventuals-bot.yml
+++ b/.github/workflows/update-eventuals-bot.yml
@@ -54,7 +54,7 @@ jobs:
       # submodule.
       - name: Check if PR and issue already exist
         env:
-          REPO: ${{ github.repository }}
+          REPO: ${{ inputs.owner }}/${{ inputs.repo_name }}
           GITHUB_TOKEN: ${{ secrets.private_repo_access_as_rebot_token }}
         run: ./check-if-issue-and-pr-exist.sh Update+eventuals Updating+eventuals+failed
         working-directory: ${{ inputs.devtools_directory }}/.github/workflows/scripts

--- a/.github/workflows/update-eventuals-bot.yml
+++ b/.github/workflows/update-eventuals-bot.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Grab current commit and shallow_since
         id: current_info
         run: |
-          echo ::set-output name=current_commit::$(git log -n 1 --pretty=format:"%H")
-          echo ::set-output name=current_shallow_since::$(git log -n 1 --date=raw --pretty=format:"%cd")   
+          echo ::set-output name=latest_commit::$(git log -n 1 --pretty=format:"%H")
+          echo ::set-output name=latest_shallow_since::$(git log -n 1 --date=raw --pretty=format:"%cd")   
 
       - uses: actions/checkout@v3
         with:
@@ -44,10 +44,10 @@ jobs:
 
       - name: Update WORKSPACE.bazel
         run: |
-          current_commit="${{ steps.current_info.outputs.current_commit }}"
-          current_shallow_since="${{ steps.current_info.outputs.current_shallow_since }}"
+          commit="${{ steps.current_info.outputs.latest_commit }}"
+          shallow_since="${{ steps.current_info.outputs.latest_shallow_since }}"
           chmod +x ${{ inputs.devtools_directory }}/.github/workflows/scripts/update-eventuals-git-repository.sh
-          ${{ inputs.devtools_directory }}/.github/workflows/scripts/update-eventuals-git-repository.sh WORKSPACE.bazel $current_commit "$current_shallow_since"
+          ${{ inputs.devtools_directory }}/.github/workflows/scripts/update-eventuals-git-repository.sh WORKSPACE.bazel $commit "$shallow_since"
         shell: bash
 
       # The following step checks whether the issue and pull request have already been created or not for the same
@@ -141,6 +141,8 @@ jobs:
       #   with:
       #     number: ${{ steps.pr.outputs.pull-request-number }}
       #     labels: mergequeue-failed
+      #     repo: ${{ inputs.owner }}/${{ inputs.repo_name }}
+      #     github_token: ${{ secrets.private_repo_access_as_rebot_token }}
 
       # We add "mergequeue-ready" label to the pull request created or updated in the step
       # "Create Pull Request or update existing" in order to merge the changes in automatic mode.
@@ -150,4 +152,6 @@ jobs:
       #   uses: actions-ecosystem/action-add-labels@v1
       #   with:
       #     number: ${{ steps.pr.outputs.pull-request-number }}
-      #     labels: mergequeue-ready  
+      #     labels: mergequeue-ready
+      #     repo: ${{ inputs.owner }}/${{ inputs.repo_name }}
+      #     github_token: ${{ secrets.private_repo_access_as_rebot_token }}

--- a/.github/workflows/update-eventuals-bot.yml
+++ b/.github/workflows/update-eventuals-bot.yml
@@ -1,0 +1,153 @@
+name: Create PR for updating eventuals for the specific repo
+
+on:
+  workflow_call:
+    inputs:
+      devtools_directory:
+        required: true
+        type: string
+      repo_name:
+        required: true
+        type: string
+      owner:
+        required: true
+        type: string  
+    secrets:
+      private_repo_access_as_rebot_token:
+        required: true
+
+jobs:
+  Update-Eventuals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install buildifier for .bzl files
+        run: brew install buildifier
+        shell: bash
+
+      - uses: actions/checkout@v3
+        with:
+          ref: "artur.pr-bot-for-updating-eventuals"
+          submodules: "recursive"  
+
+      - name: Grab current commit and shallow_since
+        id: current_info
+        run: |
+          echo ::set-output name=current_commit::$(git log -n 1 --pretty=format:"%H")
+          echo ::set-output name=current_shallow_since::$(git log -n 1 --date=raw --pretty=format:"%cd")   
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: ${{ secrets.private_repo_access_as_rebot_token }}
+          repository: ${{ inputs.owner }}/${{ inputs.repo_name }}
+          ref: 'artur.add-dev-tools'
+
+      - name: Update WORKSPACE.bazel
+        run: |
+          current_commit="${{ steps.current_info.outputs.current_commit }}"
+          current_shallow_since="${{ steps.current_info.outputs.current_shallow_since }}"
+          chmod +x ${{ inputs.devtools_directory }}/.github/workflows/scripts/update-eventuals-git-repository.sh
+          ${{ inputs.devtools_directory }}/.github/workflows/scripts/update-eventuals-git-repository.sh WORKSPACE.bazel $current_commit "$current_shallow_since"
+        shell: bash
+
+      # The following step checks whether the issue and pull request have already been created or not for the same
+      # submodule.
+      - name: Check if PR and issue already exist
+        env:
+          REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.private_repo_access_as_rebot_token }}
+        run: ./check-if-issue-and-pr-exist.sh Update+eventuals Updating+eventuals+failed
+        working-directory: ${{ inputs.devtools_directory }}/.github/workflows/scripts
+
+      - name: Close open issue
+        if: env.ISSUE_EXISTS == 'true' && env.PR_EXISTS == 'false'
+        uses: peter-evans/close-issue@v2
+        with:
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          comment: |
+            Auto-closing this issue because the Pull Request it was created for was closed.
+      # When the "Close open issue" step closes issue we need to set env variable ISSUE_EXISTS to False.
+      # If we don't set it then "Wait for build to succeed" step won't start and we won't get build status and
+      # next step "Create an issue" won't create a new issue
+      - name: Set ISSUE_EXISTS to False
+        if: (env.ISSUE_EXISTS == 'true' && env.PR_EXISTS == 'false')
+        run: echo "ISSUE_EXISTS=false" >> $GITHUB_ENV
+  
+      - name: Create Pull Request
+        id: pr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          committer: Rebot <96078724+reboot-dev-bot@users.noreply.github.com>
+          author: Rebot <96078724+reboot-dev-bot@users.noreply.github.com>
+          commit-message: Update eventuals in git_repository bazel rule
+          title: Update eventuals
+          body: Update eventuals commit and shallow_since in 'git_repository' bazel rule.
+          branch: update-eventuals
+          base: main
+          add-paths: WORKSPACE.bazel
+          token: ${{ secrets.private_repo_access_as_rebot_token }}
+          # If a previous run had already created the branch like `submodule-sync.latest`,
+          # remove that first, start fresh. This ensures that the PR we
+          # open or update always has exactly one commit in it.
+          delete-branch: true
+
+      - name: Auto-approve PR
+        # We only need to do this when the PR is first created, not on subsequent
+        # updates.
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.private_repo_access_as_rebot_token }}
+          number: ${{ steps.pr.outputs.pull-request-number }}    
+
+      # Here we are waiting for the PR check status in order to use it in next steps.
+      # See docs: https://github.com/marketplace/actions/wait-for-check
+      - name: Wait for build to succeed
+        # If the issue already exists, we don't need to wait, because the only reason we wait is to decide whether to open the issue.
+        if: env.ISSUE_EXISTS == 'false' && (steps.pr.outputs.pull-request-operation == 'created' || steps.pr.outputs.pull-request-operation == 'updated')
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-build
+        with:
+          token: ${{ secrets.private_repo_access_as_rebot_token }}
+          checkName: 'Build'
+          ref: ${{ steps.pr.outputs.pull-request-head-sha }}
+          repo: ${{ inputs.repo_name }}
+          owner: ${{ inputs.owner }}
+          timeoutSeconds: 3600
+
+      # In case checks of PR failed and the issue hadn't been created before the following action creates issue.
+      # See docs: https://github.com/actions-ecosystem/action-create-issue
+      - name: Create an issue
+        if: steps.wait-for-build.outputs.conclusion == 'failure'
+        uses: actions-ecosystem/action-create-issue@v1
+        with:
+          github_token: ${{ secrets.private_repo_access_as_rebot_token }}
+          title: Updating eventuals failed
+          body: |
+            ## Please check the PR for updating eventuals
+            Pull Request URL - ${{ steps.pr.outputs.pull-request-url }}
+      # The "mergequeue-failed" label gets added by the Mergequeue bot when it has previously seen
+      # the mergequeue-ready label on a PR but the checks failed and Mergequeue couldn't merge the PR.
+      # When that happens it removes the "mergequeue-ready" label and adds "mergequeue-failed".
+      # Even if we later add the "mergequeue-ready" label to the PR again, Mergequeue won't merge a PR
+      # with a new "mergequeue-ready" label if it still has an (old) "mergequeue-failed" label on it.
+      # So we must remove the mergequeue-failed label before re-adding mergequeue-ready.
+      # The following action removes the "mergequeue-failed" label if it exist.
+      # If it doesn't exist the action returns error but doesn't fail the whole job (by default).
+      # See docs: https://github.com/actions-ecosystem/action-remove-labels
+      # - name: Remove label "mergequeue-failed"
+      #   if: steps.pr.outputs.pull-request-operation == 'created' || steps.pr.outputs.pull-request-operation == 'updated'
+      #   uses: actions-ecosystem/action-remove-labels@v1
+      #   with:
+      #     number: ${{ steps.pr.outputs.pull-request-number }}
+      #     labels: mergequeue-failed
+
+      # We add "mergequeue-ready" label to the pull request created or updated in the step
+      # "Create Pull Request or update existing" in order to merge the changes in automatic mode.
+      # See docs of the action: https://github.com/actions-ecosystem/action-add-labels
+      # - name: Add label "mergequeue-ready"
+      #   if: steps.pr.outputs.pull-request-operation == 'created' || steps.pr.outputs.pull-request-operation == 'updated'
+      #   uses: actions-ecosystem/action-add-labels@v1
+      #   with:
+      #     number: ${{ steps.pr.outputs.pull-request-number }}
+      #     labels: mergequeue-ready  


### PR DESCRIPTION
Adds scripts to have the possibility to create auto-PR on every push in main in `3rdparty/eventuals` repo in order to update `eventuals` in the repository needed.
`NOTE:` `make sure` that all branches\refs are tied to main in scripts before merging this PR!!! Also `uncomment all stuff for merge labels`!!!