### PR TITLE
Add .style.yapf file for standard YAPF (Python) style

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+based_on_style = google
+indent_width = 4
+column_limit = 79

--- a/.style.yapf
+++ b/.style.yapf
@@ -2,3 +2,6 @@
 based_on_style = google
 indent_width = 4
 column_limit = 79
+
+split_arguments_when_comma_terminated = true
+dedent_closing_brackets = true


### PR DESCRIPTION
Before this PR we were using custom configuration in
`reboot-dev/respect`'s `.vscode.json` to set the desired YAPF style for
our Python code.

With this PR we create a `.style.yapf` file that matches that style here 
in `dev-tools`, and make it available for other repos to symlink. This is
a step towards using the same Python style for all repos.