### PR TITLE
Activate MergeQueue for the 3rdparty/dev-tools repo

### DIFF
--- a/.mergequeue/config.yml
+++ b/.mergequeue/config.yml
@@ -1,0 +1,31 @@
+version: 1.0.0
+merge_rules:
+  labels:
+    trigger: mergequeue-ready
+    skip_line: ""
+    merge_failed: ""
+    skip_delete_branch: ""
+  update_latest: true
+  delete_branch: false
+  use_rebase: true
+  enable_comments: true
+  ci_timeout_mins: 0
+  preconditions:
+    number_of_approvals: 1
+    use_github_mergeability: false
+    conversation_resolution_required: true
+  merge_mode:
+    type: default
+    parallel_mode: null
+  auto_update:
+    enabled: false
+    label: ""
+    max_runs_for_update: 0
+  merge_commit:
+    use_title_and_body: false
+  merge_strategy:
+    name: squash
+    override_labels:
+      squash: ""
+      merge: ""
+      rebase: mergequeue-rebase


### PR DESCRIPTION
We've previously activated MergeQueue for ~all our other repos, and it's
confusing that dev-tools doesn't use it yet. This PR checks in our
standard MergeQueue config.