### PR TITLE
Add YAPF to the standard formatting checks

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -1,13 +1,13 @@
 # The name of this file should be `action.yml` , `action.yaml` or `Dockerfile`.
 # Should be run only on macOS or Ubuntu.
 
-name: 'Check Code Style'
-desciption: 'Check files for correct code style'
+name: "Check Code Style"
+desciption: "Check files for correct code style"
 
 inputs:
-  os: 
-    description: 'Specify operating system on which this action will run'
-  
+  os:
+    description: "Specify operating system on which this action will run"
+
 runs:
   using: "composite"
   steps:
@@ -19,17 +19,17 @@ runs:
       # we have preinstalled clang-format-10/11/12. By default the symlink
       # to /usr/bin/clang-format-11 is set. That's why we will not be able
       # to run successfully the checks for code style cause the minimum
-      # version required is `12` (see `dev-tools/check-code-style/check_style.sh` 
+      # version required is `12` (see `dev-tools/check-code-style/check_style.sh`
       # especially check_clang_format() function).
       # That's why the main idea of this step is just setting the symlink to
       # /usr/bin/clang-format-12, nothing more. Thus we will be able to run all
-      # checks with correct version of clang-format using GitHub Actions. 
+      # checks with correct version of clang-format using GitHub Actions.
       run: |
         # Before we recreate the symlink we should delete
         # the existing one.
         sudo rm /etc/alternatives/clang-format
         # Recreate symlink 'clang-format'
-        sudo ln -s /usr/bin/clang-format-12 /etc/alternatives/clang-format 
+        sudo ln -s /usr/bin/clang-format-12 /etc/alternatives/clang-format
       shell: bash
 
     # On macOS we should install clang-format.
@@ -37,10 +37,10 @@ runs:
       if: inputs.os == 'macos-latest'
       run: |
         brew install clang-format@13
-      shell: bash   
+      shell: bash
 
     - name: Check all .cc , .h, .proto files for correct code style
-      run: | 
+      run: |
         chmod +x ${{ github.action_path }}/check_style_of_all_files.sh
         ${{ github.action_path }}/check_style_of_all_files.sh
       shell: bash
@@ -52,5 +52,10 @@ runs:
     - name: Check all .bzl, .bazel files for correct code style
       run: |
         chmod +x ${{ github.action_path }}/check_style_bzl.sh
-        ${{ github.action_path }}/check_style_bzl.sh    
+        ${{ github.action_path }}/check_style_bzl.sh
       shell: bash
+
+    - name: Run YAPF to test if Python code is correctly formatted
+      uses: AlexanderMelde/yapf-action@master
+      with:
+        args: --verbose --exclude '**/submodules/**'


### PR DESCRIPTION
In #48 we added a standard `.style.yapf` file to teach all our YAPF (Python formatters) how to behave.

This PR adds YAPF to our set of standard formatting checks run at PR-time. This check has been shown to work in https://github.com/reboot-dev/respect/pull/422 - but that PR was a little short-sighted since it only acts on the `reboot-dev/respect` repo. This PR takes the same awesome check but makes it available to all our repos.

(Subsequent PRs will move `reboot-dev/respect` over to using that standard formatting check workflow)

Note that automated formatting had some opinions about quotes in YAML files. I deny everything. 🤷🏻 

TESTED: prototyped using this check in the `reboot-dev/pyprotoc-plugin` repo, which is another place it'll get used in the future.