### PR TITLE
Use full path to 'brew' since GitHub recently removed it from PATH

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -31,6 +31,9 @@ runs:
     - name: Install clang-format-13 if macOS
       if: inputs.os == 'macos-latest'
       run: |
+        # TODO(benh): is 'brew' not in PATH on macOS like it is not in
+        # the PATH for Linux? If so, where does GitHub install 'brew'
+        # on a macOS runner?
         brew install clang-format@13
       shell: bash
 
@@ -40,8 +43,14 @@ runs:
         ${{ github.action_path }}/check_style_of_all_files.sh
       shell: bash
 
-    - name: Install buildifier for .bzl files
+    - name: Install buildifier for .bzl files (macos)
+      if: inputs.os == 'macos-latest'
       run: brew install buildifier
+      shell: bash
+
+    - name: Install buildifier for .bzl files (ubuntu)
+      if: inputs.os == 'ubuntu-latest'
+      run: /home/linuxbrew/.linuxbrew/bin/brew install buildifier
       shell: bash
 
     - name: Check all .bzl, .bazel files for correct code style


### PR DESCRIPTION
GitHub recently removed `brew` from `PATH` in this [PR](https://github.com/actions/runner-images/pull/6240).

This commit uses the full path on Linux as suggested [here](https://github.com/mikhailkoliada/runner-images/blob/935669cb34f634093417b92e4590bf819a2ba915/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1#L93).