### PR TITLE
Correct PATH to include 'buildifier'

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -16,7 +16,7 @@ runs:
       run: |
         # Install Clang 13 (including clang-format-13) through LLVM's preferred mechanism:
         #   https://apt.llvm.org/
-        wget https://apt.llvm.org/llvm.sh 
+        wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 13
         rm ./llvm.sh
@@ -54,7 +54,12 @@ runs:
       shell: bash
 
     - name: Check all .bzl, .bazel files for correct code style
+      # Since the `buildifier` binary used by `check_style_bzl.sh` is installed
+      # by `brew`, and since `brew`'s binaries are not placed on the `$PATH` on
+      # GitHub's machines, we must manualy put it on the path by `eval`ing
+      # `brew shellenv`.
       run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         chmod +x ${{ github.action_path }}/check_style_bzl.sh
         ${{ github.action_path }}/check_style_bzl.sh
       shell: bash


### PR DESCRIPTION
With #58 we updated the path used to invoke `brew`, since it was removed from the `$PATH`. However, it turns out that the binaries installed via `brew`, notably our `buildifier`, had also fallen off the PATH.

This PR completes the suggestion quoted in #58 by `eval`ing `brew shellenv`, which will place `buildifier` back on the PATH.

TESTED: ran this action from a bogus PR
        (https://github.com/reboot-dev/respect/pull/968) and saw it
        pass, after it had previously failed.