### PR TITLE
Fix submodule sync

### DIFF
--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -165,31 +165,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         number: ${{ steps.pr.outputs.pull-request-number }}
 
-    # Here we are waiting for the PR check status in order to use it in next steps.
-    # See docs: https://github.com/marketplace/actions/wait-for-check
-    - name: Wait for build to succeed
-      # If the issue already exists, we don't need to wait, because the only reason we wait is to decide whether to open the issue.
-      if: env.ISSUE_EXISTS == 'false' && (steps.pr.outputs.pull-request-operation == 'created' || steps.pr.outputs.pull-request-operation == 'updated')
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      id: wait-for-build
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        checkName: 'Build and Test'
-        ref: ${{ steps.pr.outputs.pull-request-head-sha }}
-        timeoutSeconds: 3600
-
-    # In case checks of PR failed and the issue hadn't been created before the following action creates issue.
-    # See docs: https://github.com/actions-ecosystem/action-create-issue
-    - name: Create an issue
-      if: steps.wait-for-build.outputs.conclusion == 'failure'
-      uses: actions-ecosystem/action-create-issue@v1
-      with:
-        github_token: ${{ secrets.private_repo_access_as_rebot_token }}
-        title: Submodule sync failed for "${{ matrix.path }}"
-        body: |
-          ## Please check the PR for submodule "${{ matrix.path }}"
-          Pull Request URL - ${{ steps.pr.outputs.pull-request-url }}
-
     # The "mergequeue-failed" label gets added by the Mergequeue bot when it has previously seen
     # the mergequeue-ready label on a PR but the checks failed and Mergequeue couldn't merge the PR.
     # When that happens it removes the "mergequeue-ready" label and adds "mergequeue-failed".


### PR DESCRIPTION
Before this PR, `submodule-sync.yml` assumed that every PR it creates will run exactly one status check called "Build and Test", which it will wait to complete before merging. It would sit there and wait, burning an action runner's worth of resources, while waiting for this test to complete.

With our recent changes to `respect`'s workflows that repo no longer has such a status check, meaning that its submodule syncs were never completing. Also, our tests run long enough now that the wait time for them to complete is burning a lot of action runner resources.

This PR removes the requirement that `submodule-sync` wait for a status check. It will immediately assign the `mergequeue-ready` label and stop, letting mergequeue take it from there.

The downside to this is that `submodule-sync` will no longer file an issue when the PR fails to pass its checks. We will have to either create those issues manually or else find a more efficient and flexible way to respond to those failures.

TESTED: testing submodule-sync is difficult, since a change needs to be
        checked in before it's picked up by workflows like those in
        `reboot-dev/respect`. I'm moderately confident that this simple
        remove-only change will work, so I propose we merge this PR and
        verify post-merge.