### PR TITLE
Introduce shared isort config file

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,12 @@
 [settings]
+# Instead of keeping a separate list of files and directories that `isort`
+# should ignore, just have it follow the `.gitignore` file.
 skip_gitignore = true
+
+# Don't follow symlinks so that we don't go outside of our git repo.
 follow_links = false
+
+# The following two lines are needed to produce output that is compatible with
+# yapf.
+multi_line_output = 3
+include_trailing_comma = true

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+skip_gitignore = true
+follow_links = false


### PR DESCRIPTION
`isort` is a tool that helps us sort our Python imports in a consistent way. By having a shared configuration file we can have our VSCode auto-format our files as we write them.

A future PR can add pre-submit checks that new Python code is formatted with `isort`, but we'll first need to bring all repos in line with this new style.

Here's the effect `isort` will have on our existing code:
* https://github.com/reboot-dev/respect/pull/1091
* https://github.com/reboot-dev/respect-examples/pull/29