### PR TITLE
Add `isort` code style check

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -89,7 +89,7 @@ runs:
       run: |
         ISORT_CONFIG_FILE_PATH='./.isort.cfg'
         if [ -f "$ISORT_CONFIG_FILE_PATH" ]; then
-          echo ::set-output name=found::true
+          echo "found=true" >> $GITHUB_OUTPUT
         fi
       shell: bash
 

--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -84,6 +84,19 @@ runs:
       with:
         args: --verbose --exclude '**/submodules/**'
 
+    - name: Determine if isort is set up for this repo
+      id: find-isort
+      run: |
+        ISORT_CONFIG_FILE_PATH='./.isort.cfg'
+        if [ -f "$ISORT_CONFIG_FILE_PATH" ]; then
+          echo ::set-output name=found::true
+        fi
+      shell: bash
+
+    - name: Run isort to test if Python imports are correctly formatted
+      if: steps.find-python.outputs.found == 'true' && steps.find-isort.outputs.found == 'true'
+      uses: isort/isort-action@v1.1.0
+
     - name: Check JSON, YAML, Markdown, and more with Prettier
       uses: creyD/prettier_action@v4.2
       with:


### PR DESCRIPTION
In #66 we introduced an `isort` config that repos can use to automatically sort Python `import`s. This commit adds a check to ensure that the imports are indeed sorted. This check is active only if `isort` is activated in the repo, as indicated by an `.isort.cfg` file being present at the top-level of the repo.

TESTED: saw check correctly flag a non-`isort`ed file in [this test run](https://github.com/reboot-dev/respect/actions/runs/3567763894/jobs/5995847235).

PS: the warning flagged in that test run, about `::set-output` being deprecated, will be addressed in https://github.com/3rdparty/dev-tools/issues/68.