### PR TITLE
Remove deprecated use of ::set-output

### DIFF
--- a/.github/workflows/scripts/per-submodule-build-matrix.sh
+++ b/.github/workflows/scripts/per-submodule-build-matrix.sh
@@ -7,6 +7,6 @@ git submodule update --recursive --remote
 # The step generates one output: `path_matrix`.
 # `path_matrix` output contains list of all submodules within a repo.
 # The flag is used by the main build job.
-echo "::set-output name=path_matrix::[$(git config --file ../../../../../.gitmodules --get-regexp path | \
+echo "path_matrix=[$(git config --file ../../../../../.gitmodules --get-regexp path | \
 awk '{ print $2 }' | \
-awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]"
+awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]" >> $GITHUB_OUTPUT

--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -72,7 +72,7 @@ runs:
       # if there is a *.py file in the path that the YAPF action would check.
       run: |
         if [[ -n $(find . -name *.py -not -path "**/submodules/**") ]]; then
-          echo ::set-output name=found::true
+          echo "found=true" >> $GITHUB_OUTPUT
         fi
       shell: bash
 


### PR DESCRIPTION
Replacing it with `$GITHUB_OUTPUT` as described here:
  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Part of https://github.com/3rdparty/dev-tools/issues/68