### PR TITLE
Fix two issues with isort configuration and check

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,10 @@ follow_links = false
 # yapf.
 multi_line_output = 3
 include_trailing_comma = true
+
+# isort has difficulty determining which Python code is "first-party" vs
+# "third-party" in our setup. That makes it make strange (and machine-dependent)
+# decisions about which sections certain imports go into. Avoid that whole
+# problem by simply not having multiple sections - this is what we were used to
+# anyway.
+no_sections = true

--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -95,7 +95,15 @@ runs:
 
     - name: Run isort to test if Python imports are correctly formatted
       if: steps.find-python.outputs.found == 'true' && steps.find-isort.outputs.found == 'true'
-      uses: isort/isort-action@v1.1.0
+      id: run-isort
+      shell: bash
+      # Install and run `isort` manually instead of using the GitHub Action
+      # provided by the community; that action swallows the STDOUT, so we won't
+      # be told what's wrong with our diffs.
+      # The chosen version of isort is the version installed on our Codespaces.
+      run: |
+        pip install isort==5.10.1
+        isort --check --diff .
 
     - name: Check JSON, YAML, Markdown, and more with Prettier
       uses: creyD/prettier_action@v4.2


### PR DESCRIPTION
The two issues are:
1. isort turns out to have difficulties separating first-party and third-party libraries, which it uses to create separate sections of imports. This results in machine-dependent sorting of imports, which is bad. For example, the PR in reboot-dev/respect-examples#32 is failing to merge because of this mismatch. Since we actually don't care about the sections (we weren't using them before), disable sections to get reliable import ordering across machines.
2. The isort GitHub Action turns out to swallow important debug info because it swallows STDOUT. Install and run `isort` manually instead.