### PR TITLE
Bring yapf action into line with Codesapces

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -82,7 +82,7 @@ runs:
       if: steps.find-python.outputs.found == 'true'
       uses: AlexanderMelde/yapf-action@master
       with:
-        args: --verbose --exclude '**/submodules/**'
+        args: --verbose --exclude '**/submodules/**' --style '{based_on_style:google,indent_width:4,column_limit:79}'
 
     - name: Determine if isort is set up for this repo
       id: find-isort


### PR DESCRIPTION
On save, our Codespaces are configured to format python code using the google style version of `yapf` but our build and test action does not. This is causing a test failure with the addition of `tests/resemble:golden_file_py`.