### PR TITLE
Update `prettier_action` from broken v4.2 to v4.3

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -106,7 +106,7 @@ runs:
         isort --check --diff .
 
     - name: Check JSON, YAML, Markdown, and more with Prettier
-      uses: creyD/prettier_action@v4.2
+      uses: creyD/prettier_action@v4.3
       with:
         dry: True
         prettier_options: --check ./


### PR DESCRIPTION
We were bitten by https://github.com/creyD/prettier_action/issues/113, which breaks our code style check and therefore our ability to submit PRs.

The fix is to update that action to v4.3. And to yell and gesticulate wildly about how GitHub Actions shouldn't change the major version of the `npm` runtime without us taking action!