### PR TITLE
Line length: ignore whole files

### DIFF
--- a/check-code-style/check_style.sh
+++ b/check-code-style/check_style.sh
@@ -35,6 +35,13 @@ check_line_length() {
       skip_next_line=false
       (( number++ )) && continue
     fi
+    # If a single line says "ignore", then ignore all subsequent lines. This is
+    # useful for files imported from other sources that can't be formatted.
+    if [[ $line == *"check_line_length ignore"* ]]; then
+      return ${status}
+    fi
+    # If a line says "skip", then skip the next line. This is useful for single
+    # lines that are too long, but that can't be broken up.
     if [[ $line == *"check_line_length skip"* ]]; then
       skip_next_line=true
     fi


### PR DESCRIPTION
Before this commit we couldn't get `check_style.sh` to ignore a whole file; we've gotten pretty far by ignoring only singular lines!

However, now we need to copy in some files that aren't produced by us, and that we can't reasonably reformat to fit our style. So we need to have a way to ignore whole files.

This commit adds a new `check_line_length ignore` option, which will cause the whole remainder of the file it is found in to be ignored.