### PR TITLE
Unify code style checks run by pre-commit hook and Github Action

### DIFF
--- a/check-code-style/action.yml
+++ b/check-code-style/action.yml
@@ -11,102 +11,60 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install clang-format-13 if Ubuntu
+    - name: Install code checking tools if on Ubuntu
       if: inputs.os == 'ubuntu-latest'
       run: |
-        # Install Clang 13 (including clang-format-13) through LLVM's preferred mechanism:
+        # Install Clang (including clang-format) through LLVM's preferred mechanism:
         #   https://apt.llvm.org/
+        CLANG_VERSION=14
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 13
+        sudo ./llvm.sh ${CLANG_VERSION}
         rm ./llvm.sh
-        sudo apt-get install clang-format-13
+        sudo apt-get install -y clang-format-${CLANG_VERSION}
         sudo rm -rf /var/lib/apt/lists/*
         # Remove existing symlink to clang-format and replace it.
         sudo rm /etc/alternatives/clang-format
-        sudo ln -s /usr/bin/clang-format-13 /etc/alternatives/clang-format
+        sudo ln -s /usr/bin/clang-format-${CLANG_VERSION} /etc/alternatives/clang-format
+
+        # Install buildifier.
+        BUILDIFIER_VERSION=5.1.0
+        wget https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION}/buildifier-linux-amd64
+        chmod +x ./buildifier-linux-amd64
+        sudo mv ./buildifier-linux-amd64 /usr/local/bin/buildifier
+
+        # Install prettier.
+        NODE_VERSION=16
+        NPM_VERSION=8.19.2
+        PRETTIER_VERSION=2.7.1
+        curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash -
+        sudo apt-get update
+        sudo apt-get install -y nodejs
+        sudo rm -rf /var/lib/apt/lists/*
+        sudo npm install -g npm@${NPM_VERSION}
+        sudo npm install -g prettier@${PRETTIER_VERSION}
+
       shell: bash
 
-    # On macOS we should install clang-format.
-    - name: Install clang-format-13 if macOS
+    - name: Warn and fail if on MacOS.
       if: inputs.os == 'macos-latest'
       run: |
-        # TODO(benh): is 'brew' not in PATH on macOS like it is not in
-        # the PATH for Linux? If so, where does GitHub install 'brew'
-        # on a macOS runner?
-        brew install clang-format@13
+        echo "This github action does not support macos."
+        echo "If you need macos support, feel free to contribute the necessary install steps."
+        exit 1
       shell: bash
 
-    - name: Check all .cc , .h, .proto files for correct code style
+    - name: Install python tools
       run: |
-        chmod +x ${{ github.action_path }}/check_style_of_all_files.sh
-        ${{ github.action_path }}/check_style_of_all_files.sh
+        pip install \
+          yapf==0.33.0 \
+          mypy==1.2.0 \
+          isort==5.12.0
       shell: bash
 
-    - name: Install buildifier for .bzl files (macos)
-      if: inputs.os == 'macos-latest'
-      run: brew install buildifier
-      shell: bash
-
-    - name: Install buildifier for .bzl files (ubuntu)
-      if: inputs.os == 'ubuntu-latest'
-      run: /home/linuxbrew/.linuxbrew/bin/brew install buildifier
-      shell: bash
-
-    - name: Check all .bzl, .bazel files for correct code style
-      # Since the `buildifier` binary used by `check_style_bzl.sh` is installed
-      # by `brew`, and since `brew`'s binaries are not placed on the `$PATH` on
-      # GitHub's machines, we must manualy put it on the path by `eval`ing
-      # `brew shellenv`.
+    - name: Run code style checks on all code.
       run: |
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        chmod +x ${{ github.action_path }}/check_style_bzl.sh
-        ${{ github.action_path }}/check_style_bzl.sh
+        SCRIPT_PATH=${{ github.action_path }}/../check-style.sh
+        chmod +x ${SCRIPT_PATH}
+        ${SCRIPT_PATH} --full
       shell: bash
-
-    # TODO(rjh): consider replacing this with 'dorny/paths-filter@v2' rather than us rolling our own
-    # filter checking code.
-    - name: Determine whether there are any Python files
-      id: find-python
-      # The incantation here will set the `found` output for this step to 'true'
-      # if there is a *.py file in the path that the YAPF action would check.
-      run: |
-        if [[ -n $(find . -name *.py -not -path "**/submodules/**") ]]; then
-          echo "found=true" >> $GITHUB_OUTPUT
-        fi
-      shell: bash
-
-    - name: Run YAPF to test if Python code is correctly formatted
-      # We only run YAPF when there are Python files to be checked, since YAPF
-      # errors out when there aren't.
-      if: steps.find-python.outputs.found == 'true'
-      uses: AlexanderMelde/yapf-action@master
-      with:
-        args: --verbose --exclude '**/submodules/**'
-
-    - name: Determine if isort is set up for this repo
-      id: find-isort
-      run: |
-        ISORT_CONFIG_FILE_PATH='./.isort.cfg'
-        if [ -f "$ISORT_CONFIG_FILE_PATH" ]; then
-          echo "found=true" >> $GITHUB_OUTPUT
-        fi
-      shell: bash
-
-    - name: Run isort to test if Python imports are correctly formatted
-      if: steps.find-python.outputs.found == 'true' && steps.find-isort.outputs.found == 'true'
-      id: run-isort
-      shell: bash
-      # Install and run `isort` manually instead of using the GitHub Action
-      # provided by the community; that action swallows the STDOUT, so we won't
-      # be told what's wrong with our diffs.
-      # The chosen version of isort is the version installed on our Codespaces.
-      run: |
-        pip install isort==5.10.1
-        isort --check --diff .
-
-    - name: Check JSON, YAML, Markdown, and more with Prettier
-      uses: creyD/prettier_action@v4.3
-      with:
-        dry: True
-        prettier_options: --check ./

--- a/check-code-style/check_style.sh
+++ b/check-code-style/check_style.sh
@@ -147,7 +147,8 @@ check_style_of_files_in_commit() {
     return 1
   fi
 
-  files=$(git diff --cached --name-only --diff-filter=ACM HEAD | grep -iE '\.(cc|h)$')
+  # NOTE: Make sure that the file extensions matches the file extensions in `check_style_of_all_files.sh`.
+  files=$(git diff --cached --name-only --diff-filter=ACM HEAD | grep -iE '\.(cc|cpp|h|hpp|proto)$')
   for file in ${files}; do
     check_style "${file}"
 

--- a/check-code-style/check_style_of_all_files.sh
+++ b/check-code-style/check_style_of_all_files.sh
@@ -10,8 +10,9 @@ check_style_of_all_files() {
   # anyone using this can exclude what ever directory they want rather than assume
   # that everyone using this will want to exclude the 'submodules' directory.
   # NOTE: do not forget to do the same in the 'check_style_bzl.sh'!!!
-  # https://github.com/3rdparty/dev-tools/blob/main/check-code-style/check_style_bzl.sh 
+  # https://github.com/3rdparty/dev-tools/blob/main/check-code-style/check_style_bzl.sh
   IFS=:
+  # NOTE: Make sure that the file extensions matches the file extensions in `check_style.sh`.
   file_paths=$(find . -type f \( -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' -o -name '*.proto' \) -not -path "*/submodules/*")
   unset IFS
 

--- a/check-style.sh
+++ b/check-style.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# This script runs the same code checks as are run in our github action runners,
+# as specified in `actions.yml`, namely:
+# * check_style_of_all_files.sh - clang-format and extra line length checking).
+# * check_style_bzl.sh - buildifier, but 10x slower.
+# * yapf
+# * isort
+# * prettier
+#
+
+
+# Unset variable would be a sign of programmer error. We are not using '-e' in
+# this script as we'd like to handle these cases ourselves where relevant, i.e.,
+# allow more than one code check failure per run.
+set -u
+
+# Work from the git root. This is important to help some tools pick up the
+# correct configuration.
+git_root=$(git rev-parse --show-toplevel)
+cd "${git_root}"
+
+# Get all files under version control. These are the superset of files we will
+# want to check.
+affected_files=$(git ls-tree --full-tree --name-only -r HEAD)
+
+# Define a cummulative status code for the script. The value is Updated through
+# 'run_check' when running checks. A status code creater than 0 will indicate
+# that one or more checks failed.
+status_code=0
+
+# Run a code check command and update the cummulative error code.
+run_check() {
+    echo $1
+    time $@
+    status_code=$(($status_code + $?))
+}
+
+# Helper function to filter affected files by extension.
+get_files_by_extension() {
+    filter=""
+    for ext in $@; do
+        filter="\\.$(echo $ext | sed -e 's|^\.||')$|${filter}"
+    done
+    filter=$(echo $filter | sed -e 's/|$//')
+
+    echo $affected_files | tr ' ' '\n' | egrep $filter
+}
+
+# Check files that we can clang-format.
+clang_format_files=$(get_files_by_extension .cc .cpp .h .hpp .proto)
+if [ ! -z "${clang_format_files}" ]; then
+    # Run clang-format. In fact, run our wrapper script around-clang format that
+    # also contains logic for checking the line length.
+    #
+    # ISSUE https://github.com/reboot-dev/respect/issues/1371: This script is
+    # very slow as we process each file sequentially and does the line length
+    # checking in bash.
+    dev_tools_path=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    run_check "${dev_tools_path}/check-code-style/check_style_of_all_files.sh"
+fi
+
+# Check bazel files
+bazel_files=$(get_files_by_extension .bzl .bazel BUILD WORKSPACE)
+if [ ! -z "${bazel_files}" ]; then
+    # ISSUE https://github.com/reboot-dev/respect/issues/1383: This script is
+    # about 10 times slower than invoking buildifier directly and it doesn't do
+    # much more.
+    dev_tools_path=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    run_check "${dev_tools_path}/check-code-style/check_style_bzl.sh"
+fi
+
+# Check python files.
+python_files=$(get_files_by_extension .py)
+if [ ! -z "${python_files}" ]; then
+    # Run yapf.
+    run_check yapf -d -p ${python_files}
+
+    # Run isort
+    run_check isort --check --diff ${python_files}
+fi
+
+# Check files that we can check with prettier.
+# Turns out it is all of them.
+if [ ! -z "${affected_files}" ]; then
+    # Run prettier.
+    run_check prettier --ignore-unknown --check ${affected_files}
+fi
+
+# Return the cummulative status code. The status code will be zero if all checks
+# completed successfully and non-zero otherwise. If the script exits with a
+# non-zero value, the commit is aborted.
+exit $status_code

--- a/pre-commit
+++ b/pre-commit
@@ -1,36 +1,6 @@
 #!/bin/bash
 
-# Check for existence of git.
-which git >/dev/null
-if [[ $? != 0 ]]; then
-  printf "Failed to find 'git' (please install or update your path)\n"
-  exit 1
-fi
-
-# Get top-level directory path.
-top_level_path=$(git rev-parse --show-toplevel)
-
-# Get the path to 'check_style.sh' file.
-check_style_sh_path=$(find ${top_level_path} | grep "dev-tools/check-code-style/check_style.sh")
-
-if [[ ${#check_style_sh_path} == 0 ]]; then
-  printf "There is no 'check_style.sh' in your repo!\n"
-  printf "Make sure you have submodule 'dev-tools' cloned and initialized from:\n"
-  printf "https://github.com/3rdparty/dev-tools \n"
-  exit 1
-fi
-
-source ${check_style_sh_path}
-
-run_checks(){
-   check_style_of_files_in_commit
-}
-
-case "$1" in
-  --help )
-    echo "Performs checks on files to be committed"
-    ;;
-  * )
-    run_checks
-    ;;
-esac
+# Run the check-style script from dev-tools as pre-commit hook.
+SCRIPTPATH="$(dirname -- "$( readlink -f -- "$0"; )")"
+CHECK_STYLE_SCRIPT="${SCRIPTPATH}/check-style.sh"
+exec $CHECK_STYLE_SCRIPT

--- a/pre-commit
+++ b/pre-commit
@@ -3,4 +3,4 @@
 # Run the check-style script from dev-tools as pre-commit hook.
 SCRIPTPATH="$(dirname -- "$( readlink -f -- "$0"; )")"
 CHECK_STYLE_SCRIPT="${SCRIPTPATH}/check-style.sh"
-exec $CHECK_STYLE_SCRIPT
+exec $CHECK_STYLE_SCRIPT --pre-commit


### PR DESCRIPTION
This PR unifies the check that we run in pre-commit hook and the checks that we run in our Github Actions. As discussed in https://github.com/reboot-dev/respect/issues/1370 these had diverged and this PR fixes this divergence.

The PR also addresses https://github.com/reboot-dev/respect/issues/1383, by removing the use of `check_style_bzl.sh` and calling `buildifier` directly.

As part of the update of `actions.yml`, all of the necessary ubuntu installation is collected in a single setup, and after deliberation with @benh, the support for running the Github Action on `macos` has been abandoned for now. Neither `eventuals` nor `respect` makes use of a macos Github Action runner.

https://github.com/reboot-dev/respect/issues/1374 has been closed in favour of keeping the pre-commit hook fast: as we run the check on all files online before we can merge, we will have sufficient protection.

The PR does not address https://github.com/reboot-dev/respect/issues/1371, regarding the speed and use of our home rolled `clang-format`-and-line-length script, and these scripts are used in this PR. The total time for running the github action also remains the same, around 2m where 1m25s is installation of tools, 5 seconds is all our other code checks and 30s is calling `check_style_of_all_files.sh`.