### PR TITLE
Check for changes to staged files

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,6 +1,29 @@
 #!/bin/bash
 
+# Exit on first error.
+set -e
+
 # Run the check-style script from dev-tools as pre-commit hook.
 SCRIPTPATH="$(dirname -- "$( readlink -f -- "$0"; )")"
 CHECK_STYLE_SCRIPT="${SCRIPTPATH}/check-style.sh"
-exec $CHECK_STYLE_SCRIPT --pre-commit
+$CHECK_STYLE_SCRIPT --pre-commit
+
+# Abort if there are uncommitted changed to staged files. This would indicate
+# that we have saved the file after the initial `git add`. This could happen
+# either because we've fixed formatting of a file of because vscode is sometimes
+# very slow at running it's post save tasks.
+files_in_commit=$(git diff --cached --name-only --diff-filter=ACM HEAD)
+files_with_unstaged_changes=$(git ls-files . -m)
+changed_files=""
+for file in $files_with_unstaged_changes; do
+    if [ ! -z "$(echo $files_in_commit | grep $file)" ]; then
+        changed_files="$file $changed_files"
+    fi
+done
+if [ ! -z "$changed_files" ]; then
+    echo "There are unstaged changes to staged files:"
+    for file in ${changed_files}; do
+        echo "M $file"
+    done
+    exit 1
+fi


### PR DESCRIPTION
Fixes https://github.com/reboot-dev/respect/issues/1408 by extending the pre-commit hook to also checking that no changes were made to the staged files.