### PR TITLE
Improve error message for pre-commit hook

### DIFF
--- a/check-style.sh
+++ b/check-style.sh
@@ -128,7 +128,7 @@ fi
 # Turns out it is all of them.
 if [ ! -z "${affected_files}" ]; then
     # Run prettier.
-    run_check prettier --ignore-unknown --check ${affected_files}
+    run_check prettier --ignore-unknown --check --loglevel=warn ${affected_files}
 fi
 
 # Return the cummulative status code. The status code will be zero if all checks

--- a/pre-commit
+++ b/pre-commit
@@ -1,12 +1,28 @@
 #!/bin/bash
 
-# Exit on first error.
-set -e
+# Helper function to print error message to user in case of error.
+# Optionally takes arguments that will be printed in an additional "Hint" line.
+print_error() {
+    local CO='\033[0;31m' # Color, red.
+    local NC='\033[0m' # No color.
+    echo -e "${CO}"
+    echo "WARNING NO FILES WERE COMMITTED: One or more pre-commit checks failed!"
+    echo "Please, carefully check the output above to see what went wrong."
+    if [ $# -gt 0 ]; then
+        echo ""
+        echo "Hint: $@."
+    fi
+    echo -e "${NC}"
+}
 
 # Run the check-style script from dev-tools as pre-commit hook.
 SCRIPTPATH="$(dirname -- "$( readlink -f -- "$0"; )")"
 CHECK_STYLE_SCRIPT="${SCRIPTPATH}/check-style.sh"
 $CHECK_STYLE_SCRIPT --pre-commit
+if [ ! $? -eq 0 ]; then
+    print_error "Code style check failed"
+    exit 1
+fi
 
 # Abort if there are uncommitted changed to staged files. This would indicate
 # that we have saved the file after the initial `git add`. This could happen
@@ -25,5 +41,6 @@ if [ ! -z "$changed_files" ]; then
     for file in ${changed_files}; do
         echo "M $file"
     done
+    print_error "Unstaged changes"
     exit 1
 fi


### PR DESCRIPTION
This PR fixes https://github.com/reboot-dev/respect/issues/1410 by
1) Adding an error message in case of a failed pre-commit:
```

WARNING NO FILES WERE COMMITTED: One or more pre-commit checks failed!
Please, carefully check the output above to see what went wrong.

Hint: Code style check failed.

```
2) Suppresses some of the verbose output from `prettier` in the `check-style.sh` script that might cause confusion.
