### PR TITLE
Factor out print_error from pre-commit

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,22 +1,9 @@
 #!/bin/bash
 
-# Helper function to print error message to user in case of error.
-# Optionally takes arguments that will be printed in an additional "Hint" line.
-print_error() {
-    local CO='\033[0;31m' # Color, red.
-    local NC='\033[0m' # No color.
-    echo -e "${CO}"
-    echo "WARNING NO FILES WERE COMMITTED: One or more pre-commit checks failed!"
-    echo "Please, carefully check the output above to see what went wrong."
-    if [ $# -gt 0 ]; then
-        echo ""
-        echo "Hint: $@."
-    fi
-    echo -e "${NC}"
-}
+SCRIPTPATH="$(dirname -- "$( readlink -f -- "$0"; )")"
+source ${SCRIPTPATH}/pre-commit-print-error
 
 # Run the check-style script from dev-tools as pre-commit hook.
-SCRIPTPATH="$(dirname -- "$( readlink -f -- "$0"; )")"
 CHECK_STYLE_SCRIPT="${SCRIPTPATH}/check-style.sh"
 $CHECK_STYLE_SCRIPT --pre-commit
 if [ ! $? -eq 0 ]; then

--- a/pre-commit-print-error
+++ b/pre-commit-print-error
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Helper function to print error message to user in case of error.
+# Optionally takes arguments that will be printed in an additional "Hint" line.
+print_error() {
+    local CO='\033[0;31m' # Color, red.
+    local NC='\033[0m' # No color.
+    echo -e "${CO}"
+    echo "WARNING NO FILES WERE COMMITTED: One or more pre-commit checks failed!"
+    echo "Please, carefully check the output above to see what went wrong."
+    if [ $# -gt 0 ]; then
+        echo ""
+        echo "Hint: $@."
+    fi
+    echo -e "${NC}"
+}


### PR DESCRIPTION
Companion to https://github.com/reboot-dev/respect/pull/1829.

Now that we have pre-commit scripts in multiple places, it's nice to be able to use the `print_error` function separately from the rest of the pre-commit script.