### PR TITLE
Make keyword/named args work the same as unnamed args

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -5,3 +5,4 @@ column_limit = 79
 
 split_arguments_when_comma_terminated = true
 dedent_closing_brackets = true
+split_before_named_assigns = false


### PR DESCRIPTION
In particular, this means that `yapf` will respect commas and not try and do weird line wrapping even though we have included a comma!!!