### PR TITLE
`submodule-sync`: make fewer path assumptions

### DIFF
--- a/.github/workflows/scripts/per-submodule-build-matrix.sh
+++ b/.github/workflows/scripts/per-submodule-build-matrix.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# We'll print some debug information along the way.
+echo "Started in working directory '$(pwd)'..."
+
+# Assumption: this script is being run from _inside_ a submodule, but is
+# supposed to act on the repo that _contains_ that submodule. Change our working
+# directory accordingly.
+cd "$(git rev-parse --show-toplevel)/.."
+
+gitmodules_path="$(git rev-parse --show-toplevel)/.gitmodules"
+echo "Assumed relevant '.gitmodules' file is '$gitmodules_path'"
+
 # Update references.
 git submodule update --recursive --remote
 
@@ -7,6 +18,12 @@ git submodule update --recursive --remote
 # The step generates one output: `path_matrix`.
 # `path_matrix` output contains list of all submodules within a repo.
 # The flag is used by the main build job.
-echo "path_matrix=[$(git config --file ../../../../../.gitmodules --get-regexp path | \
-awk '{ print $2 }' | \
-awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]" >> $GITHUB_OUTPUT
+output=$( \
+    echo "path_matrix=[$(git config --file "$gitmodules_path" --get-regexp path | \
+      awk '{ print $2 }' | \
+      awk '{ printf "%s\"%s\"", (NR==1?"":", "), $0 } END{ print "" }')]" \
+)
+echo "####"
+echo $output
+echo "####"
+echo $output >> $GITHUB_OUTPUT


### PR DESCRIPTION
Before this commit, `per-submodule-build-matrix.sh` assumed that the top level of the repo it was syncing was at `../../../../../`, which happened to be true for all of our repos. As of [reboot-dev/respect@`323ce51` (#3786)](https://github.com/reboot-dev/respect/pull/3786/commits/323ce51a506e99ae5452d6c584475edf4a8620fc) however, that is no longer true.

This commit makes the script look up the top-level of its containing repo dynamically, with its only
assumption being that the script is being run from a submodule itself - which still holds.

TESTED: checked that the `submodule-sync` workflow passes again for the `reboot-dev/respect` repo
where it was previously broken.