### PR TITLE
Ignore `node_modules`/`site-packages` Markdown files

### DIFF
--- a/check-style.sh
+++ b/check-style.sh
@@ -141,7 +141,8 @@ if [ ! -z "${affected_files}" ]; then
     run_check prettier --ignore-unknown --check --loglevel=warn ${affected_files}
 
     # Check documentation snippets (which can be affected by changes in any other file).
-    markdown_files=$(find . -type f \( -name "*.md" -o -name "*.mdx" \))
+    # Markdown files exclude `node_modules` (pulled NPM packages) and `site-packages` (pulled Python packages).
+    markdown_files=$(find . -type f \( -name "*.md" -o -name "*.mdx" \) -not \( -path "*/node_modules/*" -o -path "*/site-packages/*" \))
     unindent_auto_doc_script=$(find . -type f -name 'unindent_auto_doc.py')
     pre_autodocs_checksum=$(calculate_checksum $markdown_files)
     run_check markdown-autodocs -c code-block -o ${markdown_files} > /dev/null && python $unindent_auto_doc_script ${markdown_files} > /dev/null


### PR DESCRIPTION
...  in `markdown-autodocs` checksum.

Before this commit, `check-style.sh` would include all `node_modules` and `site-packages` in its
search for Markdown files to checksum. These would get `sha256sum`ed for the `markdown-autodocs`
check, which would take time. Ignoring these
folders speeds up our precommit a bit.