### PR TITLE
Ignore symlinks in style checks

### DIFF
--- a/check-style.sh
+++ b/check-style.sh
@@ -41,6 +41,8 @@ case $1 in
         exit 2
 esac
 
+# Filter out symlinks from `affected_files`. We'll check the real files.
+affected_files=$(echo "$affected_files" | xargs -r -n1 file | grep -v 'symbolic link' | cut -d: -f1 | tr '\n' ' ')
 
 # Unset variable would be a sign of programmer error. We are not using '-e' in
 # this script as we'd like to handle these cases ourselves where relevant, i.e.,


### PR DESCRIPTION
Our style checks were adding problems when adding symlinks to directories:
* `prettier` will error out if told to format a directory that doesn't contain any files it can format.
* `git` will report new symlinks to directories as new files.
* `prettier` will interpret symlinks to directories as directories.
* Therefore, if adding a symlink to a directory that doesn't have any `prettier`-relevant files, `prettier` will error out.

We avoid this (and any other symlink confusion) by excluding symlinks from style checks. By definition they'll point to a real file or directory that will be getting formatted anyway.