### PR TITLE
Fix issue, where we've generated non-existing names if a filename had a colon

### DIFF
--- a/check-style.sh
+++ b/check-style.sh
@@ -42,7 +42,15 @@ case $1 in
 esac
 
 # Filter out symlinks from `affected_files`. We'll check the real files.
-affected_files=$(echo "$affected_files" | xargs -r -n1 file | grep -v 'symbolic link' | cut -d: -f1 | tr '\n' ' ')
+# Use bash test operators instead of the 'file' command to avoid issues with
+# filenames containing special characters (colons, commas, etc).
+filtered_files=""
+for f in $affected_files; do
+    if [ ! -L "$f" ]; then
+        filtered_files="$filtered_files $f"
+    fi
+done
+affected_files=$(echo "$filtered_files" | xargs -r)
 
 # Unset variable would be a sign of programmer error. We are not using '-e' in
 # this script as we'd like to handle these cases ourselves where relevant, i.e.,


### PR DESCRIPTION
Without that, it fails on the Jammy image:

```
Error:  No files matching the pattern were found: "reboot/benchmarks/construct/reports/construct_2025-02-17T03".

Error:  No files matching the pattern were found: "reboot/benchmarks/construct/reports/construct_assign_sync_read_state_id_2025-02-17T03".
```

https://github.com/reboot-dev/mono/actions/runs/18268773938/job/52007624523?pr=4972


On Focal we get that:
```
./public/submodules/dev-tools/check-style.sh --full
xargs: file: No such file or directory
```
https://github.com/reboot-dev/mono/actions/runs/18267517312/job/52004088667

1) The filename truncation was broken if we have a colon as part of a filename, so we will get a non-existing file name;
2) So the `xargs` thing works differently, so it wasn't failing before, but silently continuing with an error and removed the non-existing file from the list of affected files, but now on Jammy it passes it through and then fails when we try to invoke `prettier`.

