### PR TITLE
Format `pre-pull-docker-image/action.yml` with prettier

### DIFF
--- a/pre-pull-docker-image/action.yml
+++ b/pre-pull-docker-image/action.yml
@@ -11,8 +11,7 @@
 # adding it to a job can only help and never hurt.
 
 name: "Pre-pull Docker Image"
-description:
-  "Pull the Docker image named by a Dockerfile's first `FROM` line
+description: "Pull the Docker image named by a Dockerfile's first `FROM` line
   with retries, so that a later build in the same job finds it in the
   local image store."
 
@@ -28,8 +27,7 @@ inputs:
     required: false
     default: "5"
   initial-delay-seconds:
-    description:
-      "Delay before the second attempt; doubles after every further
+    description: "Delay before the second attempt; doubles after every further
       failed attempt, capped at 60 seconds."
     required: false
     default: "5"


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was written by an agent (Claude Code) and has **not yet been
> reviewed by a human**. Read the diff before trusting it or merging.

The `pre-pull-docker-image` action landed (#101) with two `description`
scalars wrapped in a style that `prettier --check` rejects, so the
"Code formatting" check would flag the file on every run. This wasn't
caught on #101 itself because that check currently fails during its
checkout step (`could not read Username for 'https://github.com'` —
failing on `main` pushes too, since April's last green run), before the
style check ever executes. Reformatted the file with the repo's
prettier configuration; no behavioral change.

Note for maintainers: the underlying "Code formatting" checkout failure
looks like an expired/empty `PRIVATE_REPO_ACCESS_AS_REBOT_TOKEN` secret
in this repo and is not addressed here — it needs an admin to rotate
the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
