### PR TITLE
Make the synced repository configurable

### DIFF
--- a/.github/workflows/scripts/per-submodule-build-matrix.sh
+++ b/.github/workflows/scripts/per-submodule-build-matrix.sh
@@ -3,10 +3,17 @@
 # We'll print some debug information along the way.
 echo "Started in working directory '$(pwd)'..."
 
-# Assumption: this script is being run from _inside_ a submodule, but is
-# supposed to act on the repo that _contains_ that submodule. Change our working
-# directory accordingly.
-cd "$(git rev-parse --show-toplevel)/.."
+# Move to the repository whose submodules we want to sync. By default this
+# script assumes it runs from _inside_ a submodule and acts on the repo that
+# directly _contains_ that submodule (one level up). When the submodule is
+# nested more than one level deep, the caller can set `SUBMODULE_SYNC_ROOT` to
+# the target repository's directory (relative to the checkout root) to act on
+# that repository instead.
+if [ -n "${SUBMODULE_SYNC_ROOT:-}" ]; then
+  cd "${GITHUB_WORKSPACE}/${SUBMODULE_SYNC_ROOT}"
+else
+  cd "$(git rev-parse --show-toplevel)/.."
+fi
 
 gitmodules_path="$(git rev-parse --show-toplevel)/.gitmodules"
 echo "Assumed relevant '.gitmodules' file is '$gitmodules_path'"

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -30,12 +30,23 @@ on:
       devtools_directory:
         required: true
         type: string
+      submodule_sync_root:
+        description: >-
+          Directory of the repository whose submodules to sync, relative to
+          the checkout root. Defaults (empty) to the repository that directly
+          contains the `dev-tools` submodule. Set it (for example to ".") when
+          `dev-tools` is nested more than one level deep and the sync should
+          act on an ancestor repository instead.
+        required: false
+        type: string
+        default: ""
     secrets:
       private_repo_access_as_rebot_token:
         required: true
 
 env:
   SCRIPTS_DIRECTORY: ${{ inputs.devtools_directory }}/.github/workflows/scripts
+  SUBMODULE_SYNC_ROOT: ${{ inputs.submodule_sync_root }}
 
 jobs:
   # Since we want to create one PR per each submodule on submodule change


### PR DESCRIPTION
The reusable `submodules-sync` workflow assumed its `dev-tools` submodule is a direct submodule of the repository whose submodules should be synced, and always acted on the repo one level up (`cd "$(git rev-parse --show-toplevel)/.."`).

That breaks when `dev-tools` is nested more than one level deep — e.g. when a repository vendors another repository (which itself carries `dev-tools`) as a submodule. In that case the workflow enumerates and syncs the *inner* repository's submodules instead of the caller's.

Add an optional `submodule_sync_root` input, piped through to `per-submodule-build-matrix.sh` as `SUBMODULE_SYNC_ROOT`, naming the repository directory to act on relative to the checkout root. When it is unset the workflow keeps its previous behavior, so existing callers are unaffected; a caller whose `dev-tools` is nested can pass e.g. "." to sync its own top-level submodules.